### PR TITLE
Feature/irsa removal

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -9,7 +9,7 @@ locals {
   namespace             = try(var.kong_config.namespace, "kong")
   create_namespace      = try(var.kong_config.create_namespace, true)
   chart                 = "kong"
-  chart_version         = try(var.kong_config.chart_version, "2.16.5")
+  chart_version         = try(var.kong_config.chart_version, null)
   repository            = try(var.kong_config.repository, "https://charts.konghq.com")
   values                = try(var.kong_config.values, [])
 

--- a/locals.tf
+++ b/locals.tf
@@ -17,15 +17,18 @@ locals {
   telemetry_dns         = try(var.kong_config.telemetry_dns, null)
   cert_secret_name      = try(var.kong_config.cert_secret_name, null)
   key_secret_name       = try(var.kong_config.key_secret_name, null)
-  kong_external_secrets = try(var.kong_config.kong_external_secrets, "kong-cluster-cert")
+  kong_external_secrets = try(var.kong_config.kong_external_secrets, "konnect-client-tls")
+  tls_cert                                            = "tls.crt"
+  tls_key                                             = "tls.key"
   secret_volume_length  = try(length(yamldecode(var.kong_config.values[0])["secretVolumes"]), 0)
-  external_secret_service_account_name                 = "external-secret-irsa"
+  external_secret_service_account_name                = "external-secret-irsa"
   external_secrets_irsa_role_name                     = "external-secret-irsa"
   external_secrets_irsa_role_name_use_prefix          = true
   external_secrets_irsa_role_path                     = "/"
   external_secrets_irsa_role_permissions_boundary_arn = null
   external_secrets_irsa_role_description              = "IRSA for external-secrets operator"
   external_secrets_irsa_role_policies                 = {}
+
 
   set_values = [
     {
@@ -46,11 +49,11 @@ locals {
     },
     {
       name  = "env.cluster_cert"
-      value = "/etc/secrets/${local.kong_external_secrets}/kong_cert"
+      value = "/etc/secrets/${local.kong_external_secrets}/${local.tls_cert}"
     },
     {
       name  = "env.cluster_cert_key"
-      value = "/etc/secrets/${local.kong_external_secrets}/kong_key"
+      value = "/etc/secrets/${local.kong_external_secrets}/${local.tls_key}"
     },
     {
       name  = "env.lua_ssl_trusted_certificate"

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "kubernetes_service_account_v1" "external_secret_sa" {
 # Note, this source module does not has "s" in eks-blueprints-addon
 
 module "external_secret_irsa" {
-  count   = var.enable_kong_konnect ? 1 : 0
+  # count   = var.enable_kong_konnect ? 1 : 0
   source  = "aws-ia/eks-blueprints-addon/aws"
   version = "1.1.0"
 
@@ -98,7 +98,7 @@ module "external_secret_irsa" {
 ###########Secret Store###########
 
 resource "kubectl_manifest" "secretstore" {
-  count = var.enable_kong_konnect ? 1 : 0
+  # count = var.enable_kong_konnect ? 1 : 0
   yaml_body  = <<YAML
 apiVersion: external-secrets.io/v1beta1
 kind: SecretStore
@@ -125,7 +125,7 @@ YAML
 ###########External Secret###########
 
 resource "kubectl_manifest" "secret" {
-  count = var.enable_kong_konnect ? 1 : 0
+  # count = var.enable_kong_konnect ? 1 : 0
   yaml_body  = <<YAML
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
@@ -160,7 +160,7 @@ module "kong_helm" {
   source           = "aws-ia/eks-blueprints-addon/aws"
   version          = "1.1.0"
 
-  create           = var.enable_kong_konnect
+  create           = true
   chart            = local.name
   chart_version    = local.chart_version
   repository       = local.repository

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 ###########Namespace###########
 
 resource "kubernetes_namespace_v1" "kong" {
-  count = var.enable_kong_konnect && local.create_namespace && local.namespace != "kube-system" ? 1 : 0
+  # count = var.enable_kong_konnect && local.create_namespace && local.namespace != "kube-system" ? 1 : 0
 
   metadata {
     name = local.namespace
@@ -51,7 +51,7 @@ resource "kubernetes_service_account_v1" "external_secret_sa" {
   metadata {
     name        = local.external_secret_service_account_name
     namespace   = local.namespace
-    annotations = { "eks.amazonaws.com/role-arn" : module.external_secret_irsa[0].iam_role_arn }
+    annotations = { "eks.amazonaws.com/role-arn" : module.external_secret_irsa.iam_role_arn }
   }
 
   automount_service_account_token = true
@@ -143,10 +143,10 @@ spec:
   template:
     type: kubernetes.io/tls
   data:
-  - secretKey: kong_cert
+  - secretKey: ${local.tls_cert}
     remoteRef:
       key: ${local.cert_secret_name}
-  - secretKey: kong_key
+  - secretKey: ${local.tls_key}
     remoteRef:
       key: ${local.key_secret_name}
 YAML
@@ -161,7 +161,7 @@ module "kong_helm" {
   version          = "1.1.0"
 
   create           = true
-  chart            = local.name
+  chart            = local.chart
   chart_version    = local.chart_version
   repository       = local.repository
   description      = "Kong konnect"

--- a/variables.tf
+++ b/variables.tf
@@ -18,11 +18,11 @@ variable "oidc_provider_arn" {
   type        = string
 }
 
-variable "enable_kong_konnect" {
-  description = "Enable Kong add-on"
-  type        = bool
-  default     = false
-}
+# variable "enable_kong_konnect" {
+#   description = "Enable Kong add-on"
+#   type        = bool
+#   default     = false
+# }
 
 variable "kong_config" {
   description = "Kong addon configuration values"


### PR DESCRIPTION
* Removing redundant depends on to speed up terraform plan
* Defaulting chart version to null to fetch latest always
* Making Chart name to use local.chart
* Secret Name change to be tls.crt and tls.key

Related change in samples, at https://github.com/aws-samples/terraform-eks-blueprints-kong-samples/pull/1